### PR TITLE
fix(settings/boto): switch to default AWS_S3_CALLING_FORMAT

### DIFF
--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -8,7 +8,6 @@ Adds sensible default for running app in production.
 '''
 from __future__ import absolute_import, unicode_literals
 
-from boto.s3.connection import OrdinaryCallingFormat
 from django.utils import six
 
 from .common import *  # noqa
@@ -85,12 +84,10 @@ if ENABLE_MEDIA_UPLOAD_TO_S3:
     AWS_ACCESS_KEY_ID = env('DJANGO_AWS_ACCESS_KEY_ID')
     AWS_SECRET_ACCESS_KEY = env('DJANGO_AWS_SECRET_ACCESS_KEY')
     AWS_STORAGE_BUCKET_NAME = env('DJANGO_AWS_STORAGE_BUCKET_NAME')
-    AWS_AUTO_CREATE_BUCKET = True
     AWS_QUERYSTRING_AUTH = False
-    AWS_S3_CALLING_FORMAT = OrdinaryCallingFormat()
 
-    # AWS cache settings, don't change unless you know what you're doing:
-    AWS_EXPIRY = 60 * 60 * 24 * 7
+    # AWS cache settings, don't change unless you know what you're doing.
+    AWS_EXPIRY = 60 * 60 * 24 * 7  # 1 week
 
     # TODO See: https://github.com/jschneier/django-storages/issues/47
     # Revert the following and use str after the above-mentioned bug is fixed in


### PR DESCRIPTION
OrdinaryCallingFormat throws the following error while running
collectstatic, switching back to default calling format fixes the issues.

Also, removed AWS_AUTO_CREATE_BUCKET=True settings, the bucket must be
created manually with proper settings.

Error Trackback:
```
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 351, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 343, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python2.7/dist-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 168, in handle
    collected = self.collect()
  File "/usr/local/lib/python2.7/dist-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 107, in collect
    handler(path, prefixed_path, storage)
  File "/usr/local/lib/python2.7/dist-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 305, in copy_file
    if not self.delete_file(path, prefixed_path, source_storage):
  File "/usr/local/lib/python2.7/dist-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 218, in delete_file
    if self.storage.exists(prefixed_path):
  File "/usr/local/lib/python2.7/dist-packages/storages/backends/s3boto.py", line 439, in exists
    return k.exists()
  File "/usr/local/lib/python2.7/dist-packages/boto/s3/key.py", line 539, in exists
    return bool(self.bucket.lookup(self.name, headers=headers))
  File "/usr/local/lib/python2.7/dist-packages/boto/s3/bucket.py", line 142, in lookup
    return self.get_key(key_name, headers=headers)
  File "/usr/local/lib/python2.7/dist-packages/boto/s3/bucket.py", line 192, in get_key
    key, resp = self._get_key_internal(key_name, headers, query_args_l)
  File "/usr/local/lib/python2.7/dist-packages/boto/s3/bucket.py", line 230, in _get_key_internal
    response.status, response.reason, '')
boto.exception.S3ResponseError: S3ResponseError: 301 Moved Permanently
```