### PR TITLE
refractor(email/smtp): switch to mailgun as SMTP server (heroku only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Remove `pytest-pythonpath` from dependency as it's not longer needed.
 - Replace `pytest-ipdb` with `pdbpp` as suggested by `pytest-ipdb`
 
+### Changed
+- Default SMTP server to mailgun
+
 ## [1.0.0]
 ### Added
 - latest template configuration via dict

--- a/{{cookiecutter.github_repository}}/docs/backend/server_config.md
+++ b/{{cookiecutter.github_repository}}/docs/backend/server_config.md
@@ -47,7 +47,7 @@ The deployment are managed via travis, but for the first time you'll need to set
 
 ### Heroku
 
-Run these commands to deploy a new project to Heroku:
+Run these commands to deploy this project on Heroku (substitue all references of `<heroku-app-name>` with the name your heroku application.)
 
 ```
 heroku create --ssh-git <heroku-app-name>
@@ -56,7 +56,10 @@ heroku addons:create heroku-postgresql --app=<heroku-app-name>
 heroku pg:backups schedule DATABASE_URL --at '04:00 UTC' --app=<heroku-app-name>
 heroku pg:promote DATABASE_URL --app=<heroku-app-name>
 
-heroku addons:create sendgrid:starter --app=<heroku-app-name>
+heroku addons:create mailgun --app=<heroku-app-name>
+heroku config:set EMAIL_HOST="\$MAILGUN_SMTP_SERVER" \
+                  EMAIL_HOST_USER="\$MAILGUN_SMTP_LOGIN" \
+                  EMAIL_HOST_PASSWORD="\$MAILGUN_SMTP_PASSWORD" --app=<heroku-app-name>
 
 heroku addons:create redistogo --app=<heroku-app-name>
 heroku addons:create redismonitor --url `heroku config:get REDISTOGO_URL --app=<heroku-app-name>` --app=<heroku-app-name>

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -109,11 +109,11 @@ STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 
 # EMAIL
 # ------------------------------------------------------------------------------
-DEFAULT_FROM_EMAIL = env('DJANGO_DEFAULT_FROM_EMAIL',
+DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL',
                          default='{{ cookiecutter.project_name }} <{{ cookiecutter.django_admin_email }}>')
-EMAIL_HOST = env("DJANGO_EMAIL_HOST", default='smtp.sendgrid.com')
-EMAIL_HOST_PASSWORD = env("SENDGRID_PASSWORD")
-EMAIL_HOST_USER = env('SENDGRID_USERNAME')
+EMAIL_HOST = env("EMAIL_HOST")
+EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD")
+EMAIL_HOST_USER = env('EMAIL_HOST_USER')
 EMAIL_PORT = env.int("EMAIL_PORT", default=587)
 EMAIL_SUBJECT_PREFIX = env("EMAIL_SUBJECT_PREFIX", default='[{{cookiecutter.project_name}}] ')
 EMAIL_USE_TLS = True


### PR DESCRIPTION
The email settings is no longer smtp server dependent.

closes #87 #84 