### PR TITLE
feat(settings): use `cache_db` as `SESSION_ENGINE` instead of simple `cache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Default SMTP server to mailgun
+- Use `cache_db` as `SESSION_ENGINE` instead of simple `cache`
 
 ## [1.0.0]
 ### Added

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -67,9 +67,6 @@ SESSION_COOKIE_SECURE = False
 SESSION_COOKIE_HTTPONLY = True
 SECURE_SSL_REDIRECT = env.bool("DJANGO_SECURE_SSL_REDIRECT", default=True)
 
-# Use cache for sessions
-SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-SESSION_CACHE_ALIAS = "default"
 
 ENABLE_MEDIA_UPLOAD_TO_S3 = env.bool("ENABLE_MEDIA_UPLOAD_TO_S3", default=False)
 
@@ -141,6 +138,10 @@ CACHES = {
         }
     }
 }
+
+# https://docs.djangoproject.com/en/1.8/topics/http/sessions/#using-cached-sessions
+SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+SESSION_CACHE_ALIAS = "default"
 
 # TEMPLATE CONFIGURATION
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Simple `cache` may cause non-persistent sessions, use `cache_db` as a safe
option. This uses a write-through cache – every write to the cache will
also be written to the database.

Should be changed to direct `django.contrib.sessions.backends.cache`,
while doing performance review, if necessary.

Read more: https://docs.djangoproject.com/en/1.8/topics/http/sessions/#using-cached-sessions