### PR TITLE
chore(settings): Remove gevent library for production environments

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/production.txt
+++ b/{{cookiecutter.github_repository}}/requirements/production.txt
@@ -9,7 +9,6 @@ django-storages-redux==1.3
 
 # WSGI HTTP Server
 # -------------------------------------
-gevent==1.0.2
 gunicorn==19.4.1
 
 # Caching


### PR DESCRIPTION
We are not using gevent in this project. It should be up-to developer to add it if needed.