### PR TITLE
feat(settings): Allow ADMIN_EMAIL to be set via environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.1.0-dev]
 ### Added
+- Allow admin email to be set via environment variable `DJANGO_ADMIN_EMAIL`
 - Use `bin/post_compile` to handle database migration on Heroku.
 - Switch to stable version of mkdocs 
 - Add custom user app with email as username

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -19,7 +19,8 @@ env = environ.Env()
 # People who get code error notifications.
 # In the format (('Full Name', 'email@example.com'), ('Full Name', 'anotheremail@example.com'))
 ADMINS = (
-    ('{{ cookiecutter.project_name }} Admin', '{{ cookiecutter.django_admin_email }}'),
+    ('{{ cookiecutter.project_name }} Admin',
+     env('DJANGO_ADMIN_EMAIL', default='{{ cookiecutter.django_admin_email }}')),
 )
 
 # Not-necessarily-technical managers of the site. They get broken link


### PR DESCRIPTION
- use `DJANGO_ADMIN_EMAIL` as variable name

closes #97