### PR TITLE
feat(settings): use in-built `SecurityMiddleware` instead of django-secure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Default SMTP server to mailgun
 - Use `cache_db` as `SESSION_ENGINE` instead of simple `cache`
+- Use in-built `SecurityMiddleware` instead of django-secure
 
 ## [1.0.0]
 ### Added

--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -14,7 +14,6 @@ pytz==2015.7
 # -------------------------------------
 django-environ==0.4.0
 django-sites==0.8
-django-secure==1.0.1
 python-dotenv==0.3.0
 
 # Models

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -108,6 +108,7 @@ SITE_ID = 'local'
 # this middleware classes will be applied in the order given, and in the
 # response phase the middleware will be applied in reverse order.
 MIDDLEWARE_CLASSES = (
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -255,6 +256,16 @@ MEDIA_URL = '/media/'
 
 # SLUGLIFIER
 AUTOSLUG_SLUGIFY_FUNCTION = "slugify.slugify"
+
+#  SECURITY
+# -----------------------------------------------------------------------------
+CSRF_COOKIE_HTTPONLY = False  # Allow javascripts to read CSRF token from cookies
+SESSION_COOKIE_HTTPONLY = True  # Do not allow Session cookies to be read by javascript
+
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_BROWSER_XSS_FILTER = True
+SECURE_CONTENT_TYPE_NOSNIFF = True
+X_FRAME_OPTIONS = 'DENY'
 
 # LOGGING CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -8,16 +8,10 @@ Adds sensible default for running app in production.
 '''
 from __future__ import absolute_import, unicode_literals
 
+# Third Party Stuff
 from django.utils import six
 
 from .common import *  # noqa
-
-
-# SECRET CONFIGURATION
-# ------------------------------------------------------------------------------
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
-# Raises ImproperlyConfigured exception if DJANO_SECRET_KEY not in os.environ
-SECRET_KEY = env("DJANGO_SECRET_KEY")
 
 # SITE CONFIGURATION
 # Hosts/domain names that are valid for this site.
@@ -25,12 +19,14 @@ SECRET_KEY = env("DJANGO_SECRET_KEY")
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = ["*"]
 
+SITE_SCHEME = env('SITE_SCHEME', default='https')
+
 # DJANGO_SITES
 # ------------------------------------------------------------------------------
 # see: http://django-sites.readthedocs.org
 SITES['remote'] = {
     "domain": env('SITE_DOMAIN'),
-    "scheme": env('SITE_SCHEME', default='https'),
+    "scheme": SITE_SCHEME,
     "name": env('SITE_NAME'),
 }
 SITE_ID = env("DJANGO_SITE_ID", default='remote')
@@ -48,24 +44,19 @@ INSTALLED_APPS += ("gunicorn", )
 # properly on Heroku.
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
-# django-secure
-# ------------------------------------------------------------------------------
-INSTALLED_APPS += ("djangosecure", )
+#  SECURITY
+# -----------------------------------------------------------------------------
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
+# Raises ImproperlyConfigured exception if DJANO_SECRET_KEY not in os.environ
+SECRET_KEY = env("DJANGO_SECRET_KEY")
 
-MIDDLEWARE_CLASSES = (
-    # Make sure djangosecure.middleware.SecurityMiddleware is listed first
-    'djangosecure.middleware.SecurityMiddleware',
-) + MIDDLEWARE_CLASSES
-
-# set this to 60 seconds and then to 518400 when you can prove it works
-SECURE_HSTS_SECONDS = 60
-SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS", default=True)
-SECURE_FRAME_DENY = env.bool("DJANGO_SECURE_FRAME_DENY", default=True)
-SECURE_CONTENT_TYPE_NOSNIFF = env.bool("DJANGO_SECURE_CONTENT_TYPE_NOSNIFF", default=True)
-SECURE_BROWSER_XSS_FILTER = True
-SESSION_COOKIE_SECURE = False
-SESSION_COOKIE_HTTPONLY = True
-SECURE_SSL_REDIRECT = env.bool("DJANGO_SECURE_SSL_REDIRECT", default=True)
+if SITE_SCHEME == 'https':
+    # set this to 60 seconds and then to 518400 when you can prove it works
+    SECURE_HSTS_SECONDS = env.int('DJANGO_SECURE_HSTS_SECONDS', default=60)
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_SSL_REDIRECT = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
 
 # STORAGE CONFIGURATION
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
- all functionalities of `django-secure` has now been integrated in django.
- move some settings to common, as they should be present during development
  to in-order to catch any issue.
- in production, enable `https` sepecific settings only when site is set to run
  over `https`