### PR TITLE
feat(settings): Add `REDIS_MAX_CONNECTIONS` parameter with default reduced to 10.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.1.0-dev]
 ### Added
+- Add `REDIS_MAX_CONNECTIONS` parameter with default reduced to 10.
 - Add custom branding for drf's api browser login page.
 - Allow admin email to be set via environment variable `DJANGO_ADMIN_EMAIL`
 - Use `bin/post_compile` to handle database migration on Heroku.

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -119,7 +119,8 @@ CACHES = {
             'PARSER_CLASS': 'redis.connection.HiredisParser',
             'CONNECTION_POOL_CLASS': 'redis.BlockingConnectionPool',
             'CONNECTION_POOL_CLASS_KWARGS': {
-                'max_connections': 50,
+                # Hobby redistogo on heroku only supports max. 10, increase as required.
+                'max_connections': env.int('REDIS_MAX_CONNECTIONS', default=10),
                 'timeout': 20,
             }
         }


### PR DESCRIPTION
- RedisToGo on heroku supports maximum of 10 connections