### PR TITLE
fix(vagrant/provisioner): Make ansible provisioner run in vagrant

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,7 +7,7 @@
     , "timezone": "UTC"
     , "django_admin_email": "{{ cookiecutter.project_name }} Admin <admin@example.com>"
     , "version": "0.0.0"
-    , "python_version": "2"
+    , "python3": "n"
     , "newrelic" : "y"
     , "postgis": "n"
 }

--- a/{{cookiecutter.github_repository}}/provisioner/hosts
+++ b/{{cookiecutter.github_repository}}/provisioner/hosts
@@ -5,12 +5,20 @@
 vm=1
 user=vagrant
 project_path=/home/vagrant/{{ cookiecutter.github_repository }}
+venv_path=/home/vagrant/venv
 django_requirements_file=requirements/development.txt
+django_settings="settings.development"
+pg_db={{ cookiecutter.main_module }}
+pg_user=vagrant
+pg_password=vagrant
+gunicorn_workers=2
 
 [production]
 {{ cookiecutter.main_module }}.com
 
 [production:vars]
 user=ubuntu
-project_path=/home/vagrant/{{ cookiecutter.github_repository }}
+project_path=/home/ubuntu/{{ cookiecutter.github_repository }}
+venv_path=/home/ubuntu/venv
 django_requirements_file=requirements.txt
+django_settings="settings.production"

--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/templates/supervisor_celery.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/templates/supervisor_celery.conf.j2
@@ -1,7 +1,7 @@
 {% raw %}[program:celery]
-command = {{ project_path }}/venv/bin/celery worker -A {{ project_name }} -B -l INFO --concurrency={{ celery_concurrency }}
+command = {{ venv_path }}/bin/celery worker -A {{ project_name }} -B -l INFO --concurrency={{ celery_concurrency }}
 directory = {{ project_path }}/
-user=ubuntu
+user={{ user }}
 stdout_logfile=/var/log/celery.log
 stderr_logfile=/var/log/celery.log
 {% endraw %}

--- a/{{cookiecutter.github_repository}}/provisioner/roles/common/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/common/defaults/main.yml
@@ -7,7 +7,7 @@ lc_all: "en_US.utf8"
 lc_ctype: "en_US.utf8"
 lc_collate: "en_US.utf8"
 ubuntu_release: "trusty"
-
+{%raw%}
 base_ubuntu:
   common:
     apt_packages:
@@ -17,10 +17,6 @@ base_ubuntu:
       - python-dev
       - python-setuptools
       - python-virtualenv
-      - python3
-      - python3-dev
-      - python3-setuptools
-      - python3-pip
       - sysstat
       - vim
       - fail2ban
@@ -32,3 +28,8 @@ base_ubuntu:
       - postgresql-client
       - libpq-dev
       - postgis
+  python3:
+    apt_packages:
+      - python{{ py_venv_version }}
+      - python{{ py_venv_version }}-dev
+{%endraw%}

--- a/{{cookiecutter.github_repository}}/provisioner/roles/common/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/common/tasks/main.yml
@@ -16,6 +16,11 @@
   apt_repository: repo="deb http://apt.postgresql.org/pub/repos/apt/ {{ ubuntu_release }}-pgdg main 9.5"
                   state=present
 
+- name: Add Custom Python PPA
+  apt_repository: repo="ppa:fkrull/deadsnakes"
+                  state=present
+  when: python3
+
 - name: update apt cache
   apt: update_cache=yes
 
@@ -25,9 +30,14 @@
     - { src: 'bashrc', dest: '.bashrc' }
     - { src: 'inputrc', dest: '.inputrc' }
 
-- name: install apt_get install apt_packages
+- name: apt_get install common packages
   apt: pkg={{ item }} state=present
   with_items: base_ubuntu.common.apt_packages
+
+- name: apt-get install python3 packages
+  apt: pkg={{ item }} state=present
+  with_items: base_ubuntu.python3.apt_packages
+  when: python3
 
 - name: easy_install pip
   easy_install: name=pip

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.conf.j2
@@ -34,4 +34,5 @@ server {
             proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Proto $scheme;
     }
+
 }{%endraw%}

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
@@ -2,15 +2,16 @@
 - name: get the latest code
   git: repo={{ project_repo_url }} dest={{ project_path }} version={{ repo_version }} accept_hostkey=true
   sudo: false
+  when: vm is undefined
   tags: ['deploy', 'always']
 
 - name: manually create the initial virtualenv
-  command: virtualenv {{ project_path }}/venv -p python{{ py_version }} creates={{ project_path }}/venv
+  command: virtualenv {{ venv_path }} -p python{{ py_venv_version }} creates={{ venv_path }}
   sudo: false
   tags: ['configure', 'deploy']
 
 - name: install django python dependencies
-  pip: requirements={{ project_path }}/{{ django_requirements_file }} virtualenv={{ project_path }}/venv
+  pip: requirements={{ project_path }}/{{ django_requirements_file }}  virtualenv={{ venv_path }}
   sudo: false
   tags: ['deploy']
 
@@ -19,13 +20,17 @@
   notify: restart gunicorn
   tags: ['deploy']
 
+- name: copy env configuration
+  template: src=env.env.j2 dest={{ project_path }}/.env force=no
+  tags: ['configure']
+
 - name: migrate database
-  django_manage: command=migrate app_path={{ project_path }} virtualenv={{ project_path }}/venv
+  django_manage: command=migrate app_path={{ project_path }} virtualenv={{ venv_path }}
   sudo: false
   tags: ['deploy']
 
 - name: collect static
-  django_manage: command=collectstatic app_path={{ project_path }} virtualenv={{ project_path }}/venv
+  django_manage: command=collectstatic app_path={{ project_path }} virtualenv={{ venv_path }}
   sudo: false
   tags: ['deploy']
 

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/templates/env.env.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/templates/env.env.j2
@@ -1,0 +1,3 @@
+DATABASE_URL="{% if cookiecutter.postgis == 'y' %}postgis{% else %}postgres{% endif %}{%raw%}://{{ pg_user }}:{{ pg_password }}@localhost/{{ pg_db }}"
+DJANGO_SETTINGS_MODULE="{{ django_settings }}"
+{%endraw%}

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/templates/supervisor_gunicorn.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/templates/supervisor_gunicorn.conf.j2
@@ -1,7 +1,8 @@
 {%raw%}[program:gunicorn]
-command = {{ project_path }}/venv/bin/gunicorn -c {{ gunicorn_conf_path }}/gunicorn.conf.py wsgi:application
+{% if vm %}command = {{ venv_path }}/bin/gunicorn wsgi:application
+{% else %}command = {{ venv_path }}/bin/gunicorn -c {{ gunicorn_conf_path }}/gunicorn.conf.py wsgi:application{% endif %}
 directory = {{ project_path }}
-user=ubuntu
+user={{ user }}
 stdout_logfile=/var/log/gunicorn.log
 stderr_logfile=/var/log/gunicorn.log
 {%endraw%}

--- a/{{cookiecutter.github_repository}}/provisioner/vars.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/vars.yml
@@ -4,5 +4,6 @@ project_repo_url: git@github.com:{{ cookiecutter.github_username }}/{{ cookiecut
 project_repo_remote: origin
 domain_name: {{ cookiecutter.main_module }}.com
 repo_version: master
-py_version: {{ cookiecutter.python_version }}
+python3: {% if cookiecutter.python3 == 'y' %}True{% else %}False{% endif %}
+py_venv_version: {% if cookiecutter.python3 == 'y' %}3.5{% else %}2.7{% endif %}
 pg_gis: {% if cookiecutter.postgis == 'y' %}True{% else %}False{% endif %}

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -1,5 +1,7 @@
 -r common.txt
 
+gunicorn==19.4.5
+
 # Documentation
 # -------------------------------------
 mkdocs==0.15.1
@@ -19,7 +21,6 @@ pytest-django==2.9.1
 pytest-pythonpath==0.7
 pytest-cov==2.2.1
 factory_boy==2.6.0
-pdbpp==0.8.3
 mock==1.3.0
 flake8==2.5.2
 


### PR DESCRIPTION
Vagrant ansible provisioner is now running with Django's development
settings. Changed the cookiecutter python_version question to python3.
For now, we are using nginx, supervisor and gunicorn in vagrant as well.

For consistency among various python packages, custom postgis and python3 version, I am adding custom ppa for python3.5.