### PR TITLE
Replace redistogo with heroku-redis on Heroku

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add variable in Nginx site configuration for max body size a client can send/upload.
 
 ### Changed
+- Use `REDIS_URL` instead of `REDISTOGO_URL` for production redis connection.
+- Replace redistogo with heroku-redis as default redis provider
 - Use Official Postgresql apt-repo instead of Ubuntu's default.
 - Upgrade to Django 1.9
 - Use `django_extensions` only in development

--- a/{{cookiecutter.github_repository}}/docs/backend/server_config.md
+++ b/{{cookiecutter.github_repository}}/docs/backend/server_config.md
@@ -48,8 +48,8 @@ heroku config:set EMAIL_HOST="\$MAILGUN_SMTP_SERVER" \
                   EMAIL_HOST_USER="\$MAILGUN_SMTP_LOGIN" \
                   EMAIL_HOST_PASSWORD="\$MAILGUN_SMTP_PASSWORD" --app=<heroku-app-name>
 
-heroku addons:create redistogo --app=<heroku-app-name>
-heroku addons:create redismonitor --url `heroku config:get REDISTOGO_URL --app=<heroku-app-name>` --app=<heroku-app-name>
+heroku addons:create heroku-redis:hobby-dev --app=<heroku-app-name>
+heroku addons:create redismonitor --url `heroku config:get REDIS_URL --app=<heroku-app-name>` --app=<heroku-app-name>
 
 {% if cookiecutter.newrelic == 'y' -%}
 heroku addons:create newrelic --app=<heroku-app-name>
@@ -57,7 +57,7 @@ heroku config:set NEW_RELIC_APP_NAME=<new-relic-app-name> --app=<heroku-app-name
 {%- endif %}
 
 heroku config:set DJANGO_SETTINGS_MODULE='settings.production' \
-DJANGO_SECRET_KEY=`openssl rand -base64 32` \
+DJANGO_SECRET_KEY=`openssl rand -hex 64` \
 SITE_DOMAIN=<heroku-app-name>.herokuapp.com \
 SITE_SCHEME=https \
 SITE_NAME=DJANGO_SITE_NAME_HERE --app=<heroku-app-name>

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -114,7 +114,7 @@ DATABASES['default'].update(env.db("DATABASE_URL"))  # Should not override all d
 CACHES = {
     'default': {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "{0}{1}".format(env('REDISTOGO_URL', default="redis://localhost:6379/"), 0),
+        "LOCATION": env('REDIS_URL', default="redis://localhost:6379/"),
         'OPTIONS': {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             'PARSER_CLASS': 'redis.connection.HiredisParser',


### PR DESCRIPTION
- Use `REDIS_URL` instead of `REDISTOGO_URL` url.

closes #124